### PR TITLE
Revert "Restored step spacing in progress bar"

### DIFF
--- a/css/progress.css
+++ b/css/progress.css
@@ -20,11 +20,12 @@
 }
 .progress .step {
   display: inline-block; /* http://stackoverflow.com/questions/2491068/ddg#2491072 */
-  padding-left: 0.1em;
-  padding-right: 0.1em;
+  padding-left: 0.2em;
+  padding-right: 0.2em;
   padding-top: 0.7em;
   padding-bottom: 1em;
-  clear: none;
+  float: middle;
+  clear: none;   
 }
 
 .progress .step.done span {
@@ -38,10 +39,10 @@
 
 .progress .same-topic {
   background-color: {{ site.data.colors.header-color }};
-  clear: none;
+  clear: none; 
   padding-left: 0.35em;
   padding-right: 0.35em;
-  border-radius: 1.05em;
+  border-radius: 1.05em; /*  */
   padding-top: 0.75em;
   padding-bottom: 0.3em;
 }


### PR DESCRIPTION
This does not revert it.
![grafik](https://user-images.githubusercontent.com/564768/28485827-a362673c-6e7c-11e7-8200-135005dc1e39.png)
I would like to revert it if this is ok for you.