### PR TITLE
remove / from English button

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 </head>
 
 <body>
-  <form method="get" action="/en/00-01.html">
+  <form method="get" action="en/00-01.html">
     <button class="btn" type="submit">English</button>
   </form>
   <form method="get" action="de/00-01.html">


### PR DESCRIPTION
On github pages, we do not serve fom "/" but from "/regex-tutorial/" so we need relative paths to work.
Fix: English path.

@alikahwaji Would you like to review and merge?