### PR TITLE
fix: display error message (again) when regular expression contains errors

### DIFF
--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -22,6 +22,9 @@
     <title>{{ page.title | escape }} - {{ site.data.localization.title[page.lang] }}</title>
     <script type="text/javascript">
       var current_page_id = "page-" + {{ page.path | jsonify }};
+
+      var errorMessage = "{{ site.data.localization.error.message[page.lang] }}";
+      var errorReferenceWrong = "{{ site.data.localization.error.reference[page.lang] }}";
     </script>
     <style>
     .clicked .toggle-hint:before {

--- a/js/playfield.js
+++ b/js/playfield.js
@@ -2,8 +2,11 @@
 var playfieldsLoaded = false;
 
 function translateErrorMessage(message) {
-  var translation = (errorMessages[message] || PLEASE_TRANSLATE);
-  return ERROR_MESSAGE + ": \"" + message + "\": " + translation;
+  return errorMessage + ": \"" + message + "\"";
+}
+
+function translateReferenceWrongErrorMessage(message) {
+  return errorReferenceWrong + ": \"" + message + "\"";
 }
 
 function matchTextElement(string) {
@@ -59,7 +62,7 @@ function watchExpression(playfield, examples, regex, message) {
     try {
       return RegExp(reference);
     } catch (err) {
-      message.innerHTML = translateErrorMessage(err.message) + errorReferenceWrong;
+      message.innerHTML = translateReferenceWrongErrorMessage(err.message);
       return null;
     }
   }


### PR DESCRIPTION
Fixes the JavaScript error while trying to access the undeclared Array `errorMessages` if the regular expression entered contained errors. That error caused the translated error message to not be shown at all.