### PR TITLE
fix: make challenge fail when lines match incompletely but should not match at all

### DIFF
--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -39,6 +39,10 @@
       content: "{{ site.data.localization.match.matchedIncompletely[page.lang] }}";
     }
 
+    .playfield.verbose .incompletematch.fail:after {
+      content: "{{ site.data.localization.match.shouldNotMatch[page.lang] }}";
+    }
+
     .playfield.verbose .match.ok:after {
       content: "{{ site.data.localization.match.matched[page.lang] }}";
     }

--- a/css/playfield.css
+++ b/css/playfield.css
@@ -54,6 +54,9 @@
 .playfield  .incompletematch.ok {
   background-color: {{ site.data.colors.fails }};
 }
+.playfield  .incompletematch.fail {
+  background-color: {{ site.data.colors.fails }};
+}
 .playfield  .nomatch.ok {
   background-color: {{ site.data.colors.fails }};
 }

--- a/js/playfield.js
+++ b/js/playfield.js
@@ -119,8 +119,9 @@ function watchExpression(playfield, examples, regex, message) {
 
         matchExample(match, isIncomplete, text, example);
 
-        // enforce overall result to fail if any match is incomplete
-        match = !isIncomplete;
+        // enforce overall result to fail if any expected match is incomplete
+        if (referenceInfo.shouldMatchWholeLine && !shouldNotMatch)
+          match = match && !isIncomplete;
       } else {
         unmatchExample(example);
       }


### PR DESCRIPTION
... fixes a bug in challenge 07-04 where the pattern "word" was accepted though the reference pattern says that the lines
"words" and "one word" should not match at all:

![image](https://github.com/CoderDojoPotsdam/regex-tutorial/assets/2452695/fdbfb226-e4d0-47af-bda0-edd3af024bf8)